### PR TITLE
Add fPIC flag for compiling on CentOS

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -5,6 +5,8 @@ BASE64 := base64_vendored
 
 OBJCOPY ?= true # not available by default on mac, but not needed
 
+CFLAGS += -fPIC
+
 ifeq ($(shell uname -s), Darwin)
 	SO_LD_FLAGS := -undefined dynamic_lookup -dynamiclib
 else

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -5,12 +5,11 @@ BASE64 := base64_vendored
 
 OBJCOPY ?= true # not available by default on mac, but not needed
 
-CFLAGS += -fPIC
-
 ifeq ($(shell uname -s), Darwin)
 	SO_LD_FLAGS := -undefined dynamic_lookup -dynamiclib
 else
 	SO_LD_FLAGS := -fpic -shared
+	export CFLAGS += -fpic
 endif
 
 all: ../priv/b64_nif.so

--- a/c_src/base64_vendored/Makefile
+++ b/c_src/base64_vendored/Makefile
@@ -1,4 +1,4 @@
-CFLAGS += -std=c99 -O3 -Wall -Wextra -pedantic -fPIC
+CFLAGS += -std=c99 -O3 -Wall -Wextra -pedantic
 
 # Set OBJCOPY if not defined by environment:
 OBJCOPY ?= objcopy

--- a/c_src/base64_vendored/Makefile
+++ b/c_src/base64_vendored/Makefile
@@ -1,4 +1,4 @@
-CFLAGS += -std=c99 -O3 -Wall -Wextra -pedantic
+CFLAGS += -std=c99 -O3 -Wall -Wextra -pedantic -fPIC
 
 # Set OBJCOPY if not defined by environment:
 OBJCOPY ?= objcopy


### PR DESCRIPTION
When running this on CentOS 7 I was getting a compilation error:
```
/usr/bin/ld: base64_vendored/lib/libbase64.o: relocation R_X86_64_32S against symbol `base64_table_enc_6bit' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Nonrepresentable section on output
collect2: error: ld returned 1 exit status
make: *** [../priv/b64_nif.so] Error 1
```
After looking at the different Makefiles, running clean, then applying this "fPIC" flag to the vendored Makefile this now compiles:
```
make -C deps/b64_nif/c_src/base64_vendored clean
```

This seems to now work for me now on a Mac and also on CentOS with this fix.

The full stack trace:
```
mix deps.compile b64_nif
===> Compiling b64_nif
make: Entering directory `/workspace/deps/b64_nif/c_src'
AVX2_CFLAGS=-mavx2 SSSE3_CFLAGS=-mssse3 SSE41_CFLAGS=-msse4.1 SSE42_CFLAGS=-msse4.2 AVX_CFLAGS=-mavx \
	make -C base64_vendored OBJCOPY=true 
make[1]: Entering directory `/workspace/deps/b64_nif/c_src/base64_vendored'
cc -std=c99 -O3 -Wall -Wextra -pedantic -o bin/base64.o -c bin/base64.c
cc -std=c99 -O3 -Wall -Wextra -pedantic -mavx2 -o lib/arch/avx2/codec.o -c lib/arch/avx2/codec.c
cc -std=c99 -O3 -Wall -Wextra -pedantic -o lib/arch/generic/codec.o -c lib/arch/generic/codec.c
cc -std=c99 -O3 -Wall -Wextra -pedantic  -o lib/arch/neon32/codec.o -c lib/arch/neon32/codec.c
cc -std=c99 -O3 -Wall -Wextra -pedantic  -o lib/arch/neon64/codec.o -c lib/arch/neon64/codec.c
cc -std=c99 -O3 -Wall -Wextra -pedantic -mssse3 -o lib/arch/ssse3/codec.o -c lib/arch/ssse3/codec.c
cc -std=c99 -O3 -Wall -Wextra -pedantic -msse4.1 -o lib/arch/sse41/codec.o -c lib/arch/sse41/codec.c
cc -std=c99 -O3 -Wall -Wextra -pedantic -msse4.2 -o lib/arch/sse42/codec.o -c lib/arch/sse42/codec.c
cc -std=c99 -O3 -Wall -Wextra -pedantic -mavx -o lib/arch/avx/codec.o -c lib/arch/avx/codec.c
cc -std=c99 -O3 -Wall -Wextra -pedantic -o lib/lib.o -c lib/lib.c
cc -std=c99 -O3 -Wall -Wextra -pedantic -o lib/codec_choose.o -c lib/codec_choose.c
cc -std=c99 -O3 -Wall -Wextra -pedantic -o lib/tables/tables.o -c lib/tables/tables.c
ld -r -o lib/libbase64.o lib/arch/avx2/codec.o lib/arch/generic/codec.o lib/arch/neon32/codec.o lib/arch/neon64/codec.o lib/arch/ssse3/codec.o lib/arch/sse41/codec.o lib/arch/sse42/codec.o lib/arch/avx/codec.o lib/lib.o lib/codec_choose.o lib/tables/tables.o
true --keep-global-symbols=lib/exports.txt lib/libbase64.o
cc -std=c99 -O3 -Wall -Wextra -pedantic -o bin/base64 bin/base64.o lib/libbase64.o
make[1]: Leaving directory `/workspace/deps/b64_nif/c_src/base64_vendored'
cc -O3 -o ../priv/b64_nif.so -fpic -shared -I /opt/installs/erlang/23.2.7/erts-11.1.8/include -I base64_vendored/include b64_nif.c base64_vendored/lib/libbase64.o
/usr/bin/ld: base64_vendored/lib/libbase64.o: relocation R_X86_64_32S against symbol `base64_table_enc_6bit' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Nonrepresentable section on output
collect2: error: ld returned 1 exit status
make: *** [../priv/b64_nif.so] Error 1
make: Leaving directory `/workspace/deps/b64_nif/c_src'
===> Hook for compile failed!

** (Mix) Could not compile dependency :b64_nif, "/root/.mix/rebar3 bare compile --paths="/workspace/_build/test/lib/*/ebin"" command failed. You can recompile this dependency with "mix deps.compile b64_nif", update it with "mix deps.update b64_nif" or clean it with "mix deps.clean b64_nif"
```