### PR TITLE
Dialyzer warnings - no local return

### DIFF
--- a/src/b64_nif.erl
+++ b/src/b64_nif.erl
@@ -4,10 +4,10 @@
 -on_load(init/0).
 
 encode(_Data) ->
-  exit(nif_not_loaded).
+  erlang:nif_error(nif_not_loaded).
 
 decode(_Data) ->
-  exit(nif_not_loaded).
+  erlang:nif_error(nif_not_loaded).
 
 init() ->
   Nif = filename:join([code:priv_dir(b64_nif), "b64_nif"]),


### PR DESCRIPTION
Great library! Unfortunately dialyzer hates life and complains due to the lack of a return on the nif stubs for `encode/1` and `decode/1`.

Was able to get things in a better spot by switching the stub calls to `exit/1` over to `nif_error/1` as the erlang docs suggest.